### PR TITLE
Trigger CI when Pull merge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,8 +2,7 @@
 
 name: Continuous integration
 
-on:
-  push:
+on: [push, pull_request]
 
 jobs:
   main:


### PR DESCRIPTION
Currently only push on master trigger CI workflow. With this commit,
pull_emrge will also triggered CI worklfow.