### PR TITLE
Add Access-Control-Allow-Headers

### DIFF
--- a/runtime/etc/apache2/conf-enabled/tinyows.conf
+++ b/runtime/etc/apache2/conf-enabled/tinyows.conf
@@ -6,6 +6,8 @@ ScriptAliasMatch "^/.*" /usr/local/bin/tinyows-wrapper
 <Location />
   # enable CORS (required for WFS requests)
   Header set Access-Control-Allow-Origin "*"
+  Header set Access-Control-Allow-Headers "accept, accept-encoding, authorization, content-type, \
+                                           dnt, origin, user-agent, x-csrftoken, x-requested-with"
   Header set Cache-Control "max-age=0, must-revalidate, no-cache, no-store"
 
   SetHandler fcgid-script


### PR DESCRIPTION
Add the most common CORS related headers, same as [here](https://github.com/adamchainz/django-cors-headers#cors_allow_headers-sequencestr).

This PR aims to solve issues like that:
```
Request header field X-Requested-With is not allowed by Access-Control-Allow-Headers in preflight response.
```